### PR TITLE
Replace number input with point buttons on work-style form

### DIFF
--- a/src/css/work-style.scss
+++ b/src/css/work-style.scss
@@ -118,18 +118,17 @@
     color: $base-font;
   }
 
-  .point-buttons {
+  .point-stepper {
     display: inline-flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    justify-content: flex-end;
+    gap: 6px;
   }
 
-  .point-btn {
-    min-width: 30px;
-    height: 30px;
-    padding: 0 6px;
-    font-size: 0.9rem;
+  .step-btn {
+    min-width: 38px;
+    height: 32px;
+    padding: 0 8px;
+    font-size: 0.95rem;
+    font-weight: bold;
     font-family: inherit;
     font-variant-numeric: tabular-nums;
     border: 2px solid $light-3;
@@ -139,9 +138,10 @@
     transition: background-color 0.1s ease, color 0.1s ease,
       border-color 0.1s ease;
 
-    &:hover {
+    &:hover:not(:disabled) {
+      background-color: $accent-1;
       border-color: $accent-1;
-      color: $accent-1;
+      color: $light-1;
     }
 
     &:focus-visible {
@@ -149,10 +149,9 @@
       outline-offset: 1px;
     }
 
-    &.selected {
-      background-color: $accent-1;
-      border-color: $accent-1;
-      color: $light-1;
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
     }
   }
 
@@ -554,19 +553,14 @@
   }
 
   .ws-statements .statement-row {
-    grid-template-columns: 1.25rem 1fr 2.25rem;
+    grid-template-columns: 1.25rem 1fr auto 2.25rem;
     gap: 0.4rem 0.5rem;
   }
 
-  .ws-statements .point-buttons {
-    grid-column: 1 / -1;
-    justify-content: flex-start;
-  }
-
-  .ws-statements .point-btn {
-    min-width: 28px;
-    height: 28px;
-    font-size: 0.85rem;
+  .ws-statements .step-btn {
+    min-width: 34px;
+    height: 30px;
+    font-size: 0.9rem;
   }
 
   .results-summary {

--- a/src/css/work-style.scss
+++ b/src/css/work-style.scss
@@ -94,7 +94,7 @@
 
   li {
     margin: 0;
-    padding: 0.4rem 0;
+    padding: 0.6rem 0;
     border-bottom: 1px dashed lighten($light-3, 50%);
 
     &:last-child {
@@ -102,27 +102,11 @@
     }
   }
 
-  label {
+  .statement-row {
     display: grid;
-    grid-template-columns: 60px 1.5rem 1fr;
+    grid-template-columns: 1.5rem 1fr auto 2.5rem;
     align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-  }
-
-  input[type="number"] {
-    width: 60px;
-    padding: 6px 8px;
-    font-size: 1rem;
-    border: 2px solid $light-3;
-    background-color: $light-1;
-    color: $base-font;
-    font-variant-numeric: tabular-nums;
-
-    &:focus {
-      outline: none;
-      border-color: $accent-1;
-    }
+    gap: 0.5rem 0.75rem;
   }
 
   .letter {
@@ -132,6 +116,61 @@
 
   .text {
     color: $base-font;
+  }
+
+  .point-buttons {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: flex-end;
+  }
+
+  .point-btn {
+    min-width: 30px;
+    height: 30px;
+    padding: 0 6px;
+    font-size: 0.9rem;
+    font-family: inherit;
+    font-variant-numeric: tabular-nums;
+    border: 2px solid $light-3;
+    background-color: $light-1;
+    color: $base-font;
+    cursor: pointer;
+    transition: background-color 0.1s ease, color 0.1s ease,
+      border-color 0.1s ease;
+
+    &:hover {
+      border-color: $accent-1;
+      color: $accent-1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $accent-1;
+      outline-offset: 1px;
+    }
+
+    &.selected {
+      background-color: $accent-1;
+      border-color: $accent-1;
+      color: $light-1;
+    }
+  }
+
+  .statement-value {
+    justify-self: end;
+    min-width: 2rem;
+    padding: 2px 8px;
+    text-align: center;
+    font-weight: bold;
+    font-variant-numeric: tabular-nums;
+    border: 2px solid $accent-1;
+    color: $accent-1;
+    background-color: $light-1;
+
+    &.empty {
+      border-color: lighten($light-3, 40%);
+      color: $light-3;
+    }
   }
 }
 
@@ -514,14 +553,20 @@
     padding: 0.75rem;
   }
 
-  .ws-statements label {
-    grid-template-columns: 50px 1.25rem 1fr;
-    gap: 0.4rem;
+  .ws-statements .statement-row {
+    grid-template-columns: 1.25rem 1fr 2.25rem;
+    gap: 0.4rem 0.5rem;
   }
 
-  .ws-statements input[type="number"] {
-    width: 50px;
-    padding: 4px 6px;
+  .ws-statements .point-buttons {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+
+  .ws-statements .point-btn {
+    min-width: 28px;
+    height: 28px;
+    font-size: 0.85rem;
   }
 
   .results-summary {

--- a/src/css/work-style.scss
+++ b/src/css/work-style.scss
@@ -104,7 +104,7 @@
 
   .statement-row {
     display: grid;
-    grid-template-columns: 1.5rem 1fr auto 2.5rem;
+    grid-template-columns: 1.5rem 1fr auto;
     align-items: center;
     gap: 0.5rem 0.75rem;
   }
@@ -120,56 +120,95 @@
 
   .point-stepper {
     display: inline-flex;
-    gap: 6px;
+    align-items: stretch;
+    border: 2px solid $light-3;
+    border-radius: 999px;
+    overflow: hidden;
+    background-color: $light-1;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      border-color: $accent-1;
+      box-shadow: 0 1px 0 rgba(66, 184, 131, 0.18);
+    }
   }
 
   .step-btn {
-    min-width: 38px;
+    width: 34px;
     height: 32px;
-    padding: 0 8px;
-    font-size: 0.95rem;
+    padding: 0;
+    font-size: 1.15rem;
     font-weight: bold;
+    line-height: 1;
     font-family: inherit;
-    font-variant-numeric: tabular-nums;
-    border: 2px solid $light-3;
-    background-color: $light-1;
-    color: $base-font;
+    border: 0;
+    background: transparent;
+    color: $light-3;
     cursor: pointer;
-    transition: background-color 0.1s ease, color 0.1s ease,
-      border-color 0.1s ease;
+    transition: background-color 0.12s ease, color 0.12s ease;
 
     &:hover:not(:disabled) {
       background-color: $accent-1;
-      border-color: $accent-1;
       color: $light-1;
+    }
+
+    &.step-down:hover:not(:disabled) {
+      background-color: $accent-2;
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(1px);
     }
 
     &:focus-visible {
       outline: 2px solid $accent-1;
-      outline-offset: 1px;
+      outline-offset: -2px;
     }
 
     &:disabled {
-      opacity: 0.4;
+      opacity: 0.3;
       cursor: not-allowed;
     }
   }
 
-  .statement-value {
-    justify-self: end;
-    min-width: 2rem;
-    padding: 2px 8px;
-    text-align: center;
+  .step-value {
+    min-width: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.4rem;
     font-weight: bold;
     font-variant-numeric: tabular-nums;
-    border: 2px solid $accent-1;
     color: $accent-1;
-    background-color: $light-1;
+    border-left: 2px solid $light-3;
+    border-right: 2px solid $light-3;
+    animation: stepper-bump 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
 
-    &.empty {
-      border-color: lighten($light-3, 40%);
+  .point-stepper.is-empty {
+    .step-value {
       color: $light-3;
+      animation: none;
     }
+  }
+}
+
+@keyframes stepper-bump {
+  0% {
+    transform: scale(1);
+    color: $accent-1;
+  }
+  35% {
+    transform: scale(1.45);
+    color: $dark;
+  }
+  70% {
+    transform: scale(0.95);
+  }
+  100% {
+    transform: scale(1);
+    color: $accent-1;
   }
 }
 
@@ -553,14 +592,19 @@
   }
 
   .ws-statements .statement-row {
-    grid-template-columns: 1.25rem 1fr auto 2.25rem;
+    grid-template-columns: 1.25rem 1fr auto;
     gap: 0.4rem 0.5rem;
   }
 
   .ws-statements .step-btn {
-    min-width: 34px;
+    width: 30px;
     height: 30px;
-    font-size: 0.9rem;
+    font-size: 1.05rem;
+  }
+
+  .ws-statements .step-value {
+    min-width: 2rem;
+    font-size: 0.95rem;
   }
 
   .results-summary {

--- a/src/pages/work-style.js
+++ b/src/pages/work-style.js
@@ -186,6 +186,7 @@ const ROLES = [
 ]
 
 const LETTERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+const POINT_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 const emptySection = () =>
   LETTERS.reduce((acc, l) => ({ ...acc, [l]: "" }), {})
@@ -389,26 +390,57 @@ const WorkStylePage = ({ location }) => {
                     </span>
                   </legend>
                   <ul className="ws-statements">
-                    {LETTERS.map((letter) => (
-                      <li key={letter}>
-                        <label>
-                          <input
-                            type="number"
-                            min="0"
-                            max="10"
-                            inputMode="numeric"
-                            value={answers[idx][letter]}
-                            onChange={(e) =>
-                              handleChange(idx, letter, e.target.value)
-                            }
-                          />
-                          <span className="letter">{letter})</span>
-                          <span className="text">
-                            {section.statements[letter]}
-                          </span>
-                        </label>
-                      </li>
-                    ))}
+                    {LETTERS.map((letter) => {
+                      const selected = answers[idx][letter]
+                      const numericValue = toInt(selected)
+                      return (
+                        <li key={letter}>
+                          <div className="statement-row">
+                            <span className="letter">{letter})</span>
+                            <span className="text">
+                              {section.statements[letter]}
+                            </span>
+                            <div
+                              className="point-buttons"
+                              role="radiogroup"
+                              aria-label={`Points for statement ${letter}`}
+                            >
+                              {POINT_OPTIONS.map((n) => {
+                                const isSelected = selected !== "" && numericValue === n
+                                return (
+                                  <button
+                                    key={n}
+                                    type="button"
+                                    role="radio"
+                                    aria-checked={isSelected}
+                                    className={`point-btn${
+                                      isSelected ? " selected" : ""
+                                    }`}
+                                    onClick={() =>
+                                      handleChange(
+                                        idx,
+                                        letter,
+                                        isSelected ? "" : String(n)
+                                      )
+                                    }
+                                  >
+                                    {n}
+                                  </button>
+                                )
+                              })}
+                            </div>
+                            <span
+                              className={`statement-value${
+                                selected === "" ? " empty" : ""
+                              }`}
+                              aria-label={`Selected points for statement ${letter}`}
+                            >
+                              {selected === "" ? 0 : numericValue}
+                            </span>
+                          </div>
+                        </li>
+                      )
+                    })}
                   </ul>
                 </fieldset>
               )

--- a/src/pages/work-style.js
+++ b/src/pages/work-style.js
@@ -392,6 +392,7 @@ const WorkStylePage = ({ location }) => {
                     {LETTERS.map((letter) => {
                       const selected = answers[idx][letter]
                       const numericValue = toInt(selected)
+                      const isEmpty = selected === ""
                       const canDecrement = numericValue > 0
                       const canIncrement = numericValue < 10
                       return (
@@ -401,10 +402,14 @@ const WorkStylePage = ({ location }) => {
                             <span className="text">
                               {section.statements[letter]}
                             </span>
-                            <div className="point-stepper">
+                            <div
+                              className={`point-stepper${
+                                isEmpty ? " is-empty" : ""
+                              }`}
+                            >
                               <button
                                 type="button"
-                                className="step-btn"
+                                className="step-btn step-down"
                                 aria-label={`Decrease points for statement ${letter}`}
                                 disabled={!canDecrement}
                                 onClick={() =>
@@ -415,11 +420,19 @@ const WorkStylePage = ({ location }) => {
                                   )
                                 }
                               >
-                                −1
+                                −
                               </button>
+                              <span
+                                key={numericValue}
+                                className="step-value"
+                                aria-live="polite"
+                                aria-label={`Selected points for statement ${letter}`}
+                              >
+                                {isEmpty ? 0 : numericValue}
+                              </span>
                               <button
                                 type="button"
-                                className="step-btn"
+                                className="step-btn step-up"
                                 aria-label={`Increase points for statement ${letter}`}
                                 disabled={!canIncrement}
                                 onClick={() =>
@@ -430,17 +443,9 @@ const WorkStylePage = ({ location }) => {
                                   )
                                 }
                               >
-                                +1
+                                +
                               </button>
                             </div>
-                            <span
-                              className={`statement-value${
-                                selected === "" ? " empty" : ""
-                              }`}
-                              aria-label={`Selected points for statement ${letter}`}
-                            >
-                              {selected === "" ? 0 : numericValue}
-                            </span>
                           </div>
                         </li>
                       )

--- a/src/pages/work-style.js
+++ b/src/pages/work-style.js
@@ -186,7 +186,6 @@ const ROLES = [
 ]
 
 const LETTERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
-const POINT_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 const emptySection = () =>
   LETTERS.reduce((acc, l) => ({ ...acc, [l]: "" }), {})
@@ -393,6 +392,8 @@ const WorkStylePage = ({ location }) => {
                     {LETTERS.map((letter) => {
                       const selected = answers[idx][letter]
                       const numericValue = toInt(selected)
+                      const canDecrement = numericValue > 0
+                      const canIncrement = numericValue < 10
                       return (
                         <li key={letter}>
                           <div className="statement-row">
@@ -400,34 +401,37 @@ const WorkStylePage = ({ location }) => {
                             <span className="text">
                               {section.statements[letter]}
                             </span>
-                            <div
-                              className="point-buttons"
-                              role="radiogroup"
-                              aria-label={`Points for statement ${letter}`}
-                            >
-                              {POINT_OPTIONS.map((n) => {
-                                const isSelected = selected !== "" && numericValue === n
-                                return (
-                                  <button
-                                    key={n}
-                                    type="button"
-                                    role="radio"
-                                    aria-checked={isSelected}
-                                    className={`point-btn${
-                                      isSelected ? " selected" : ""
-                                    }`}
-                                    onClick={() =>
-                                      handleChange(
-                                        idx,
-                                        letter,
-                                        isSelected ? "" : String(n)
-                                      )
-                                    }
-                                  >
-                                    {n}
-                                  </button>
-                                )
-                              })}
+                            <div className="point-stepper">
+                              <button
+                                type="button"
+                                className="step-btn"
+                                aria-label={`Decrease points for statement ${letter}`}
+                                disabled={!canDecrement}
+                                onClick={() =>
+                                  handleChange(
+                                    idx,
+                                    letter,
+                                    String(numericValue - 1)
+                                  )
+                                }
+                              >
+                                −1
+                              </button>
+                              <button
+                                type="button"
+                                className="step-btn"
+                                aria-label={`Increase points for statement ${letter}`}
+                                disabled={!canIncrement}
+                                onClick={() =>
+                                  handleChange(
+                                    idx,
+                                    letter,
+                                    String(numericValue + 1)
+                                  )
+                                }
+                              >
+                                +1
+                              </button>
                             </div>
                             <span
                               className={`statement-value${


### PR DESCRIPTION
Each statement now uses an 0–10 button row with the selected value shown
on the right, making input quicker on touch devices and removing the
number-spinner UX.