### PR TITLE
Fix mobile overflow on work-style header and family tables

### DIFF
--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -16,6 +16,8 @@
     color: $dark;
     padding: 10px;
     text-align: center;
+    min-width: 0;
+    overflow-wrap: break-word;
 }
 
 .back {
@@ -39,7 +41,7 @@
     width: 200px;
 }
 
-@media only screen and (max-width: 380px) {
+@media only screen and (max-width: 768px) {
     .back, .filler {
         display: none;
     }

--- a/src/css/work-style.scss
+++ b/src/css/work-style.scss
@@ -500,9 +500,14 @@
   grid-template-columns: 1fr;
   gap: 1rem;
 
+  > * {
+    min-width: 0;
+  }
+
   .family-block {
     border: 2px solid lighten($light-3, 40%);
     padding: 0.75rem 1rem;
+    overflow-x: auto;
   }
 
   table {


### PR DESCRIPTION
- Hide header back/filler at <=768px (was 380px) so the title fits on phones, and let the title break long words as a safety net.
- Allow family-grid items to shrink (min-width: 0) and let each family-block scroll horizontally so long role names don't push the table past the results panel.